### PR TITLE
#43 fixed: 

### DIFF
--- a/js/core/Builder.js
+++ b/js/core/Builder.js
@@ -294,6 +294,7 @@ Disjunction.Core.Builder = function(apps)
 					childView = new Class();
 					childView.dom = childElement;
 					childView.id = id;
+					childView.phase = view.phase;
 					view.addChild(childView);
 					this.prepareElement(childElement, childView);
 				}

--- a/js/core/Pointer.js
+++ b/js/core/Pointer.js
@@ -2,15 +2,11 @@
 //holds information about the pointer device
 //knows which ONE element is currently pointed to, out of the entire tree (target, not focus)
 //checks if that target has changed
-//knows (by proxy) the focus 
 //abstracts concepts of pointer to be device-agnostic
 
 Disjunction.Core.Pointer = function() //ABSTRACT / INTERFACE
 {
 	this.device = undefined;
-	//this.xChannelIndex = undefined;
-	//this.yChannelIndex = undefined;
-	//this.selectorIndex = undefined; //usually 0 for touch or mouse
 	this.isSelected = false;
 	this.wasSelected = false;
 	
@@ -22,9 +18,6 @@ Disjunction.Core.Pointer = function() //ABSTRACT / INTERFACE
 	this.position = new Disjunction.Core.Point2(); //world position of pointer within pointed element
 	this.entered = undefined;
 	this.exited = undefined;
-	
-	this.focus = undefined;
-	this.focusLast = undefined;
 	
 	this.xChannel = undefined;
 	this.yChannel = undefined;
@@ -67,44 +60,60 @@ Disjunction.Core.Pointer = function() //ABSTRACT / INTERFACE
 		return this.isSelected != this.wasSelected;
 	}
 	
-	
+	//see whether target we released over is same we selected over
 	this.isReleasedSelectedTarget = function()
 	{
 		return targetSelected === targetReleased;
 	}
 	
-	this.updateSelectedness = function() //TODO change for touch devices.
+	this.updateSelected = function() //TODO change for touch devices.
 	{
 		this.wasSelected = this.isSelected;
 		if (this.selectChannel.delta > 0)
-			this.isSelected = this.selectChannel.value > 0;
+			this.isSelected = true;
+		else if (this.selectChannel.delta < 0)
+			this.isSelected = false;
+		//...otherwise don't change select state.
 	}
 	
 	this.findTarget = function(view)
 	{
 		//transform from parent into child coordinates
-		//after all transformations down the hierarchy, the point is in the focused View's coordinate system.
+		//after all transformations down the hierarchy, the point is in the targeted View's coordinate system.
 		//TODO later: scaling; custom transform centre
 		var device = this.device;
 		this.position.x = this.xChannel.value;
 		this.position.y = this.yChannel.value;
-		//console.log(device);
-		
-		//TODO use a while loop and check that whether any element of the position vector (no matter how many) are all valid, else proceed with if-block below
-		//...although this cannot work unless we can run through an array, as we may hit other properties in JS; in C, we cannot do this dynamically at all.
-		//so maybe points should be arrays, and so should bounds? - set X, Y, Z axes.
-		//TODO or else implement 3 dimensions as well as 2.
+
+		//TODO implement for 3 dimensions as well as 2.
 		if (this.position.x !== undefined && this.position.y !== undefined) //often undefined for touch interfaces
 		{
-			//1. determine which views pointer is in (exhaustively because parents do not necessarily geometrically contain children)
-			var intersectedViews = [];
-			this.getIntersectedViews(view, this.position, intersectedViews); //in root
+			if (this.intersectsView(view))
+				this.target = view;
 			
-			//2. Select as target that intersected view which is the last rendered
+			while (this.target.children.length > 0)
+			{
+				var children = this.target.children;
+
+				var targetCandidates = [];
+				for (var i = 0; i < children.length; i++)
+				{
+					var child = children[i];
+					if (this.intersectsView(child))
+						targetCandidates.push(child);
+				}
+				
+				//break ties by selecting the highest index (last rendered)
+				if (targetCandidates.length > 0)
+				{
+					this.target = targetCandidates[targetCandidates.length - 1];
+				}
+				else
+					break;
+			}
+			
 			this.setTargetLast();
-			this.target = intersectedViews.length > 0 ? intersectedViews[intersectedViews.length-1] : undefined;
 			
-			//3. get position of pointer within target
 			if (this.target)
 			{
 				this.positionInTarget = this.position.clone();
@@ -113,50 +122,13 @@ Disjunction.Core.Pointer = function() //ABSTRACT / INTERFACE
 		}
 	}
 	
-	this.pollFocus = undefined; //function(phase)
-	//{
-		//SET THIS ON THE PHASE, to some external function (composition) 
-		//TODO use app.input & pointer (as just updated) to determine focus
-		//TODO need to tie in DOM-like approach to getting focus - keyboard
-	//}
-	
-	//adds to the intersectedViews array in BFS order
-	this.getIntersectedViews = function(viewRoot, pointerPosition, intersectedViews)
+	this.intersectsView = function(view)
 	{
-		var unvisited = [viewRoot];
-		
-		while (unvisited.length > 0)
-		{
-			var view = unvisited.shift();
-			
-			if (view.enabled && view.children)
-			{
-				//expand (stackless) BFS queue. note that this assumes a child only ever belongs to one parent - we could use a set to be sure.
-				for (var i = 0; i < view.children.length; i++)
-				{
-					var childView = view.children[i];
-					if (childView.enabled)
-					{
-						unvisited.push(childView);
-					}
-				}
-				
-				//add view if intersected
-				var pointerTargetPosition = this.positionInTarget = pointerPosition.clone();
-				view.fromWorld(pointerTargetPosition);
-				var inBounds = view.bounds.contains(pointerTargetPosition);
-				var inGeometry = view.geometry ? view.geometry.intersects(pointerTargetPosition) : true;
-				if (inBounds && inGeometry)
-					intersectedViews.push(view);
-			}
-		}
-	}
-	
-	//TODO should really run through local Controls (a leaf view), and this function should return which one the pointer is in, so we can run a simple switch on the result.
-	//note, argument bounds to be in same coordinate system as pointer itself. specific geometry is optional.
-	this.isIn = function(view) //intersects
-	{	
-		return view === this.target;
+		var pointerPositionInTarget = this.positionInTarget = this.position.clone();
+		//view.fromWorld(pointerPositionInTarget); //necessary even for root view, when it isn't a standard fullscreen, origin-positioned element.
+		var inBounds = view.bounds.containsWorld(pointerPositionInTarget);
+		var inGeometry = view.geometry ? view.geometry.intersects(pointerPositionInTarget) : true;
+		return inBounds && inGeometry;
 	}
 };
 

--- a/js/core/View.js
+++ b/js/core/View.js
@@ -358,7 +358,7 @@ Disjunction.Core.View = function(app, model)
 
 	this.focus = function()
 	{
-		disjunction.pointer.focus = this;
+		this.phase.focus = this;
 	}
 	
 	//JS - should be in extensions?

--- a/js/examples/3 - Pointer target/App.css
+++ b/js/examples/3 - Pointer target/App.css
@@ -1,0 +1,59 @@
+* { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
+
+html, body
+{
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-webkit-tap-highlight-color: rgba(0,0,0,0);
+	-webkit-tap-highlight-color: transparent;
+	margin: 0;
+	padding: 0;
+}
+
+app
+{
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+}
+
+.Block
+{
+	background-color: red;
+	height:200px;
+	width:200px;
+	
+	border: 4px solid rgba(0,0,0,0);
+	position: relative;
+}
+
+.Block > .Block
+{
+	background-color: orange;
+	height:70px;
+	width:70px;
+}
+
+.Block > .Block > .Block
+{
+	background-color: yellow;
+	height:20px;
+	width:20px;
+}
+
+.target
+{
+	border: 4px solid white;
+}
+
+.targetParent
+{
+	border: 4px solid grey;
+}
+
+.targetGrandparent
+{
+	border: 4px solid black;
+}

--- a/js/examples/3 - Pointer target/App.html
+++ b/js/examples/3 - Pointer target/App.html
@@ -1,0 +1,98 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>3 - Pointer target</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+	
+	<!-- framework prequisite polyfills -->
+	<script src="../../polyfills/x-tag-core.min.js"></script>
+	<script src="../../polyfills/ES5.js"></script>
+ 
+	<!-- framework core -->
+	<script src="../../core/Disjunction.js"></script>
+	<script src="../../core/Builder.js"></script>
+	<script src="../../core/Journal.js"></script>
+	<script src="../../core/JournalKeeper.js"></script>
+	<script src="../../core/Service.js"></script>
+	<script src="../../core/App.js"></script>
+	<script src="../../core/Phaser.js"></script>
+	<script src="../../core/Phase.js"></script>
+	<script src="../../core/Model.js"></script>
+	<script src="../../core/View.js"></script>
+	<script src="../../core/Ctrl.js"></script>
+	<script src="../../core/ServiceHub.js"></script>
+	<script src="../../core/DeviceHub.js"></script>
+	<script src="../../core/Device.js"></script>
+	<script src="../../core/DeviceChannel.js"></script>
+	<script src="../../core/Timer.js"></script>
+	<script src="../../core/Timeline.js"></script>
+	<script src="../../core/Pointer.js"></script>
+	<script src="../../core/Point2.js"></script>
+
+
+	<!-- framework extensions -->
+	<script src="../../extensions/RAFTimer.js"></script>
+	<script src="../../extensions/Mouse.js"></script>
+	<script src="../../extensions/Keyboard.js"></script>
+	<script src="../../extensions/Box2.js"></script>
+	<script src="../../extensions/Math.js"></script>
+
+	<!-- App-related implementations -->
+	<!-- NOTE directory structures and and file separations are arbitrary -- you could keep everything in the root, even in a single file. -->
+	<link  href="./App.css" rel="stylesheet">
+	<script src="./AppModel.js"></script>
+
+	<!-- Phase-related implementations -->
+	<link  href="./Phases/Main/Main.css" rel="stylesheet">
+	<script src="./Phases/Main/MainModel.js"></script>
+	<script src="./Phases/Main/MainView.js"></script>
+	<script src="./Phases/Main/MainCtrl.js"></script>
+	
+	<script src="./Views/BlockView.js"></script>
+</head>
+<body onload="disjunction.go();">
+	<common>
+		<timer class="RAF" period=""></timer>
+		<devices>
+			<device class="Mouse"></device>
+			<device class="Keyboard"></device>
+		</devices>
+		<pointer device="DEVICE_MOUSE" x="MOUSE_X" y="MOUSE_Y" select="MOUSE_BUTTON_LEFT"></pointer>
+	</common>
+	<app class="App" id="App" oncontextmenu="return false">
+		<services>
+		</services>
+		<phases>
+			<phase- class="Main" current tabindex="0" autofocus>
+				<div class="Block b">
+					<div class="Block a">
+						<div class="Block a">
+							a
+						</div>
+						<div class="Block b">
+							b
+						</div>
+						<div class="Block c">
+							c
+						</div>
+					</div>
+					<div class="Block b">
+						<div class="Block a">
+							a
+						</div>
+						<div class="Block b">
+							b
+						</div>
+						<div class="Block c">
+							c
+						</div>				
+					</div>
+				</div>
+			</phase->
+		</phases>
+	</app>
+</body>
+</html>

--- a/js/examples/3 - Pointer target/AppModel.js
+++ b/js/examples/3 - Pointer target/AppModel.js
@@ -1,0 +1,7 @@
+AppModel = function()
+{	
+	Model.call(this);
+};
+
+AppModel.prototype = Object.create(Model.prototype);
+AppModel.prototype.constructor = AppModel;

--- a/js/examples/3 - Pointer target/Phases/Main/Main.css
+++ b/js/examples/3 - Pointer target/Phases/Main/Main.css
@@ -1,0 +1,16 @@
+.Main
+{ 
+	position: absolute;
+	left: 0px;
+	top: 0px;
+	bottom: 0px;
+	right: 0px;
+	margin: 0;
+	padding: 0;
+	outline: none;
+	width: 100%;
+	height: 100%;
+	background-color: blue;
+	
+	overflow: hidden;
+}

--- a/js/examples/3 - Pointer target/Phases/Main/MainCtrl.js
+++ b/js/examples/3 - Pointer target/Phases/Main/MainCtrl.js
@@ -1,0 +1,22 @@
+MainCtrl = function()
+{ 
+	Ctrl.call(this); //extend base framework class
+	
+	/** Used to set up resources or values specific to this Ctrl / Model (and thus the entire Phase). */ 
+	this.start = function() //abstract
+	{
+	};
+	
+	/** Used to clean up resources or reset values for this Ctrl, if it is no longer needed and can be released. */ 
+	this.finish = function() //abstract
+	{
+	};
+	
+	/** Update simulation state by making changes to associated Model. */
+	this.simulate = function(deltaSec) //abstract
+	{
+	};
+};
+
+MainCtrl.prototype = Object.create(Ctrl.prototype);
+MainCtrl.prototype.constructor = MainCtrl;

--- a/js/examples/3 - Pointer target/Phases/Main/MainModel.js
+++ b/js/examples/3 - Pointer target/Phases/Main/MainModel.js
@@ -1,0 +1,7 @@
+MainModel = function()
+{
+	Model.call(this); //extend base framework class
+}; 
+
+MainModel.prototype = Object.create(Model.prototype);
+MainModel.prototype.constructor = MainModel;

--- a/js/examples/3 - Pointer target/Phases/Main/MainView.js
+++ b/js/examples/3 - Pointer target/Phases/Main/MainView.js
@@ -1,0 +1,77 @@
+MainView = function()
+{
+	View.call(this); //extend base framework class
+
+	this.bounds = new Box2();
+
+	
+	//--- abstract framework methods ---//
+	this.start = function() 
+	{
+		var dom = this.dom;
+		dom.style.display = 'block';
+		
+		//listeners for DOM events may be set up in View.start()
+		window.addEventListener( 'resize', this.onWindowResize.bind(this), true );
+		
+		//fire up the engines!
+		this.onWindowResize();
+		this.show();
+	}
+
+	this.finish = function()
+	{
+		var dom = this.dom;
+	}
+	
+	this.input = function(deltaSec)
+	{
+		var dom = this.dom;
+	
+
+	}
+	
+	
+	this.output = function(deltaSec)
+	{
+	}
+	
+	this.outputPost = function(deltaSec)
+	{
+	}
+	
+	this.show = function()
+	{
+		var dom = this.dom;
+		var style = dom.style;
+		style.visibility = "visible";
+		style.display = "block";
+	}
+	
+	this.hide = function()
+	{
+		var dom = this.dom;
+		var style = dom.style;
+		style.visibility = "hidden";
+		style.display = "none";
+	}
+	
+	//--- helper methods ---//
+	this.onWindowResize = function()
+	{
+		var dom = this.dom;
+		var width = dom.clientWidth;
+		var height = dom.clientHeight;
+		console.log(width, height);
+		this.bounds.setWidth(width);
+		this.bounds.setHeight(height);
+	}
+	
+	this.getAspectRatio = function()
+	{
+		return window.innerWidth / window.innerHeight;
+	}
+}
+
+MainView.prototype = Object.create(View.prototype);
+MainView.prototype.constructor = MainView;

--- a/js/examples/3 - Pointer target/Phases/readme.txt
+++ b/js/examples/3 - Pointer target/Phases/readme.txt
@@ -1,0 +1,1 @@
+Place user-defined Model, View (including styles) and Ctrl belonging to a Phase, here.

--- a/js/examples/3 - Pointer target/Views/BlockView.js
+++ b/js/examples/3 - Pointer target/Views/BlockView.js
@@ -1,0 +1,111 @@
+BlockView = function()
+{
+	View.call(this); //extend base framework class
+
+	this.bounds = new Box2();
+
+	//--- abstract framework methods ---//
+	this.start = function() 
+	{
+		var dom = this.dom;
+		dom.style.display = 'block';
+		
+		//listeners for DOM events may be set up in View.start()
+		window.addEventListener( 'resize', this.onWindowResize.bind(this), true );
+		
+		//fire up the engines!
+		this.onWindowResize();
+		this.show();
+	}
+	
+	this.setup2D = function(dom)
+	{
+	}
+
+	this.finish = function()
+	{
+		var dom = this.dom;
+	}
+	
+	this.input = function(deltaSec)
+	{
+		var dom = this.dom;
+		var pointer = disjunction.pointer;
+		
+		if (pointer.selectChannel.delta > 0)
+		{
+			console.log(pointer.target);
+			
+			var parent = dom.parentNode;
+			var grandparent = dom.parentNode.parentNode;
+		
+			var target = document.getElementsByClassName('target')[0];
+			var targetParent = document.getElementsByClassName('targetParent')[0];
+			var targetGrandparent = document.getElementsByClassName('targetGrandparent')[0];
+			
+			if (target)
+				target.classList.remove('target');
+			if (targetParent)
+				targetParent.classList.remove('targetParent');
+			if (targetGrandparent)
+				targetGrandparent.classList.remove('targetGrandparent')
+			
+			dom.classList.add('target');
+			if (parent.view instanceof BlockView)
+				parent.classList.add('targetParent');
+			if (grandparent.view instanceof BlockView)
+				grandparent.classList.add('targetGrandparent');
+		}	
+	}
+	
+	
+	this.output = function(deltaSec)
+	{
+		var dom = this.dom;
+		var model = this.model.model;
+	}
+	
+	this.outputPost = function(deltaSec)
+	{
+		var dom = this.dom;
+		var model = this.model.model;
+		
+		//***TODO render using Phases's Model and View (this) state; always prefer use of output() unless you have special requirements.
+	}
+	
+	this.show = function()
+	{
+		var dom = this.dom;
+		var style = dom.style;
+		style.visibility = "visible";
+		style.display = "block";
+	}
+	
+	this.hide = function()
+	{
+		var dom = this.dom;
+		var style = dom.style;
+		style.visibility = "hidden";
+		style.display = "none";
+	}
+	
+	//--- helper methods ---//
+	this.onWindowResize = function()
+	{
+		var dom = this.dom;
+		var domRect = dom.getBoundingClientRect();
+		this.bounds.x0 = domRect.left;
+		this.bounds.y0 = domRect.top;
+		this.bounds.setWidth(domRect.width);
+		this.bounds.setHeight(domRect.height);
+		console.log(dom.className, domRect, this.bounds);
+	}
+	
+	this.getAspectRatio = function()
+	{
+		return window.innerWidth / window.innerHeight;
+	}
+}
+
+MainView.prototype = Object.create(View.prototype);
+MainView.prototype.constructor = MainView;

--- a/js/examples/3 - Pointer target/Views/readme.txt
+++ b/js/examples/3 - Pointer target/Views/readme.txt
@@ -1,0 +1,1 @@
+Place user-defined Views NOT belonging to any particular Phase, here.

--- a/js/extensions/Box2.js
+++ b/js/extensions/Box2.js
@@ -23,13 +23,22 @@ Disjunction.Extensions.Box2 = function(x0, y0, x1, y1)
 		}
 	}
 	
-	this.contains = function(other)
+	this.containsLocal = function(other)
 	{
-		//console.log('/', other instanceof Point2)
 		if (other instanceof Point2)
 		{
 			return (0 <= other.x && other.x < this.getWidth() &&
 					0 <= other.y && other.y < this.getHeight());
+		}
+		return undefined;
+	}
+	
+	this.containsWorld = function(other)
+	{
+		if (other instanceof Point2)
+		{
+			return (this.x0 <= other.x && other.x < this.x1 &&
+					this.y0 <= other.y && other.y < this.y1);
 		}
 		return undefined;
 	}


### PR DESCRIPTION
Refactored Pointer intersection to assume child Views always exist within bounds of parent, greatly simplifying targeting code while still covering by far most use cases, as well as matching DFS used for rendering (i.e. such that Pointer target is sure to match what is rendered under the Pointer). Also Box2 contains elaborated to containsWorld (for use with getClientBoundingRect as the new standard to tie DOM bounds to View bounds) and containsLocal (as contains, previously).

Focus concept moved from Pointer to Phase.
Phase update cleaned up.
No more bubbling -- from now on sub-Views which wish to cause effects in their ancestors will call ancestor methods directly.
For now, Pointer selection on View-assigned DOM elements automatically sets Phase.focus (see Phase.update).
Non-root Views now have their Phase reference set.
